### PR TITLE
walk: Exclude .venv

### DIFF
--- a/jscc/testing/filesystem.py
+++ b/jscc/testing/filesystem.py
@@ -17,7 +17,7 @@ untracked = {
 }
 
 
-def walk(top=None, excluded=('.git', '.ve', '_static', 'build', 'fixtures')):
+def walk(top=None, excluded=('.git', '.ve', '.venv', '_static', 'build', 'fixtures')):
     """
     Walk a directory tree, and yield tuples consistent of a file path and file name, excluding Git files and
     third-party files under virtual environment, static, build, and test fixture directories (by default).


### PR DESCRIPTION
uv creates virtual environments in `.venv` so it would be good to exclude that directory from the standard maintenance scripts tests